### PR TITLE
ndarray3_complex datatype

### DIFF
--- a/lib/config/datatype.h
+++ b/lib/config/datatype.h
@@ -3,6 +3,9 @@
 
 /* type used for calculations */
 typedef float             pixel_type;
+#ifdef complex
+typedef float complex     complex_pixel_type;
+#endif
 
 /* type used for reading in files */
 typedef unsigned short       input_pixel_type;

--- a/lib/ndarray/ndarray3.h
+++ b/lib/ndarray/ndarray3.h
@@ -6,7 +6,6 @@
 
 #include "config/datatype.h"
 #include "util/util.h"
-#include "util/likely.h"
 
 #include "ndarray/ndarray3_generic.h"
 
@@ -75,6 +74,11 @@ extern bool ndarray3_is_isotropic( const ndarray3* n, const pixel_type eps );
 
 extern float64 ndarray3_sum_over_all_float64( const ndarray3* n );
 
+#define ndarray3_set              ndarray3_generic_set
+#define ndarray3_get              ndarray3_generic_get
+#define ndarray3_elems            ndarray3_generic_elems
+#define NDARRAY3_LOOP_OVER_START  NDARRAY3_GENERIC_LOOP_OVER_START
+#define NDARRAY3_LOOP_OVER_END    NDARRAY3_GENERIC_LOOP_OVER_END
 
 
 #ifdef __cplusplus

--- a/lib/ndarray/ndarray3.h
+++ b/lib/ndarray/ndarray3.h
@@ -8,6 +8,8 @@
 #include "util/util.h"
 #include "util/likely.h"
 
+#include "ndarray/ndarray3_generic.h"
+
 typedef struct {
 	pixel_type* p;
 	size_t sz[3]; /* PIXEL_NDIMS */
@@ -73,94 +75,6 @@ extern bool ndarray3_is_isotropic( const ndarray3* n, const pixel_type eps );
 
 extern float64 ndarray3_sum_over_all_float64( const ndarray3* n );
 
-/** TODO document
-    _INDEX3D( int i, int j, int k, int size_x, int size_y,  int size_z )
- */
-#define _INDEX3D(_i, _j, _k, _sz_x, _sz_y, _sz_z)   ((_k*_sz_y+_j) * _sz_x + _i)
-
-#define _ndarray3_index(_n, _n_i, _n_j, _n_k) \
-( \
-	(_n)->p + _INDEX3D( (_n_i), (_n_j), (_n_k), (_n)->sz[0], (_n)->sz[1], (_n)->sz[2] ) \
-)
-
-#define _ndarray3_assert_bounds(_n, _n_i, _n_j, _n_k) ( \
-		   _n_i >=0 && _n_i < _n->sz[0] \
-		&& _n_j >=0 && _n_j < _n->sz[1] \
-		&& _n_k >=0 && _n_k < _n->sz[2] \
-		)
-
-
-
-/** TODO document
- *  ndarray3_set( ndarray3* n, size_t i, size_t j, size_t k, pixel_type value )
- */
-#define _real_ndarray3_set(_n, _n_i, _n_j, _n_k, val) \
-	do { \
-		*_ndarray3_index( (_n), (_n_i), (_n_j), (_n_k) ) = (val); \
-	} while(0)
-#ifdef NDARRAY3_ASSERT_BOUNDS_ACCESS
-  #define ndarray3_set(_n, _n_i, _n_j, _n_k, val) \
-	do { \
-		if( likely(_ndarray3_assert_bounds(_n, _n_i, _n_j, _n_k)) ) { \
-			_real_ndarray3_set(_n, _n_i, _n_j, _n_k, val); \
-		} else { \
-			die("ndarray3 (%p) access [%d,%d,%d]", _n, _n_i,_n_j,_n_k); \
-		} \
-	} while(0)
-#else
-  #define ndarray3_set(_n, _n_i, _n_j, _n_k, val) \
-	_real_ndarray3_set(_n, _n_i, _n_j, _n_k, val)
-#endif /* NDARRAY3_ASSERT_BOUNDS_ACCESS */
-
-/** TODO document
- *  ndarray3_elems( ndarray3* n )
- *
- *  Number of elements in `n`. This is the product of the dimensions of `n`.
- */
-#define ndarray3_elems(_n) ( (_n)->sz[0] * (_n)->sz[1] * (_n)->sz[2] )
-
-/** TODO document
- *  ndarray3_get( ndarray3* n, size_t i, size_t j, size_t k              )
- */
-#define _real_ndarray3_get(_n, _n_i, _n_j, _n_k     )    ( *_ndarray3_index( (_n), (_n_i), (_n_j), (_n_k) )       )
-
-#ifdef NDARRAY3_ASSERT_BOUNDS_ACCESS
-  #define ndarray3_get(_n, _n_i, _n_j, _n_k           )    \
-        ( \
-          ( likely(_ndarray3_assert_bounds(_n, _n_i, _n_j, _n_k )) ) \
-        ? ( _real_ndarray3_get(_n, _n_i, _n_j, _n_k     ) ) \
-        : (  die("ndarray3 (%p) access [%d,%d,%d]", _n, _n_i, _n_j, _n_k ),0 ) \
-        )
-#else
-  #define ndarray3_get(_n, _n_i, _n_j, _n_k           )   \
-        ( _real_ndarray3_get(_n, _n_i, _n_j, _n_k     ) )
-#endif /* NDARRAY3_ASSERT_BOUNDS_ACCESS */
-
-
-/** TODO document
- *  NDARRAY3_LOOP_OVER_START( ndarray3* n, size_t i, size_t j, size_t k ) {
- *      / * code body * /
- *  } NDARRAY3_LOOP_OVER_END;
- *
- *      NDARRAY3_LOOP_OVER_START( n, i, j, k) {
- *          ndarray3_set(n, i, j, k, 0);
- *      } NDARRAY3_LOOP_OVER_END;
- */
-#define NDARRAY3_LOOP_OVER_START( _ndarray3_var, _i0, _i1, _i2 ) \
-	do { \
-	/* start of NDARRAY3_LOOP_OVER_* */ \
-		for( size_t _i0 = 0; _i0 < _ndarray3_var->sz[0]; _i0++ ) { \
-		for( size_t _i1 = 0; _i1 < _ndarray3_var->sz[1]; _i1++ ) { \
-		for( size_t _i2 = 0; _i2 < _ndarray3_var->sz[2]; _i2++ ) { \
-			/* NDARRAY3_LOOP_OVER_* body goes here */
-
-#define NDARRAY3_LOOP_OVER_END \
-			/* NDARRAY3_LOOP_OVER_* body ends here */ \
-		} \
-		} \
-		} \
-	/* end of NDARRAY3_LOOP_OVER_* */ \
-	} while(0)
 
 
 #ifdef __cplusplus

--- a/lib/ndarray/ndarray3_complex.c
+++ b/lib/ndarray/ndarray3_complex.c
@@ -25,3 +25,8 @@ ndarray3_complex* ndarray3_complex_new(const size_t sz_x, const size_t sz_y, con
 
 	return n;
 }
+
+void ndarray3_complex_free( ndarray3_complex* n ) {
+	if( ! n->wrap ) free( n->p );
+	free( n );
+}

--- a/lib/ndarray/ndarray3_complex.c
+++ b/lib/ndarray/ndarray3_complex.c
@@ -1,0 +1,29 @@
+#include "ndarray/ndarray3_complex.h"
+
+#include "util/util.h"
+
+ndarray3_complex* _ndarray3_complex_init_sz(const size_t sz_x, const size_t sz_y, const size_t sz_z) {
+	ndarray3_complex* n;
+	NEW(n, ndarray3_complex);
+
+	n->sz[0] = sz_x;
+	n->sz[1] = sz_y;
+	n->sz[2] = sz_z;
+
+	n->has_spacing = 0;
+	/* default spacing */
+	n->spacing[0] = 1;
+	n->spacing[1] = 1;
+	n->spacing[2] = 1;
+
+	return n;
+}
+
+ndarray3_complex* ndarray3_complex_new(const size_t sz_x, const size_t sz_y, const size_t sz_z) {
+	ndarray3_complex* n = _ndarray3_complex_init_sz(sz_x, sz_y, sz_z);
+
+	NEW_COUNT( n->p, complex_pixel_type, sz_x * sz_y * sz_z );
+	n->wrap = false;
+
+	return n;
+}

--- a/lib/ndarray/ndarray3_complex.c
+++ b/lib/ndarray/ndarray3_complex.c
@@ -1,7 +1,5 @@
 #include "ndarray/ndarray3_complex.h"
 
-#include "util/util.h"
-
 ndarray3_complex* _ndarray3_complex_init_sz(const size_t sz_x, const size_t sz_y, const size_t sz_z) {
 	ndarray3_complex* n;
 	NEW(n, ndarray3_complex);

--- a/lib/ndarray/ndarray3_complex.h
+++ b/lib/ndarray/ndarray3_complex.h
@@ -1,0 +1,34 @@
+#ifndef NDARRAY3_COMPLEX_H
+#define NDARRAY3_COMPLEX_H 1
+
+/* system headers */
+#include <stdlib.h>
+#include <stdbool.h>
+#include <complex.h>
+
+/* local headers */
+#include "config/datatype.h"
+
+/* structs, enums */
+typedef struct {
+	complex_pixel_type* p;
+	size_t sz[3]; /* PIXEL_NDIMS */
+	bool wrap;
+
+	bool has_spacing;
+	pixel_type spacing[3]; /* PIXEL_NDIMS */
+} ndarray3_complex;
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
+/* Function prototypes */
+
+
+
+#ifdef __cplusplus
+};
+#endif /* __cplusplus */
+
+#endif /* NDARRAY3_COMPLEX_H */

--- a/lib/ndarray/ndarray3_complex.h
+++ b/lib/ndarray/ndarray3_complex.h
@@ -9,6 +9,8 @@
 /* local headers */
 #include "config/datatype.h"
 
+#include "ndarray/ndarray3_generic.h"
+
 /* structs, enums */
 typedef struct {
 	complex_pixel_type* p;
@@ -26,6 +28,11 @@ extern "C" {
 /* Function prototypes */
 
 
+#define ndarray3_complex_set              ndarray3_generic_set
+#define ndarray3_complex_get              ndarray3_generic_get
+#define ndarray3_complex_elems            ndarray3_generic_elems
+#define NDARRAY3_COMPLEX_LOOP_OVER_START  NDARRAY3_GENERIC_LOOP_OVER_START
+#define NDARRAY3_COMPLEX_LOOP_OVER_END    NDARRAY3_GENERIC_LOOP_OVER_END
 
 #ifdef __cplusplus
 };

--- a/lib/ndarray/ndarray3_complex.h
+++ b/lib/ndarray/ndarray3_complex.h
@@ -26,6 +26,9 @@ extern "C" {
 #endif /* __cplusplus */
 
 /* Function prototypes */
+extern ndarray3_complex* _ndarray3_complex_init_sz(const size_t sz_x, const size_t sz_y, const size_t sz_z);
+extern ndarray3_complex* ndarray3_complex_new(const size_t sz_x, const size_t sz_y, const size_t sz_z);
+extern void ndarray3_complex_free( ndarray3_complex* n );
 
 
 #define ndarray3_complex_set              ndarray3_generic_set

--- a/lib/ndarray/ndarray3_generic.h
+++ b/lib/ndarray/ndarray3_generic.h
@@ -1,0 +1,98 @@
+#ifndef NDARRAY3_GENERIC_H
+#define NDARRAY3_GENERIC_H 1
+
+/* system headers */
+#include <stdlib.h>
+#include <stdbool.h>
+
+/** TODO document
+    _INDEX3D( int i, int j, int k, int size_x, int size_y,  int size_z )
+ */
+#define _INDEX3D(_i, _j, _k, _sz_x, _sz_y, _sz_z)   ((_k*_sz_y+_j) * _sz_x + _i)
+
+#define _ndarray3_index(_n, _n_i, _n_j, _n_k) \
+( \
+	(_n)->p + _INDEX3D( (_n_i), (_n_j), (_n_k), (_n)->sz[0], (_n)->sz[1], (_n)->sz[2] ) \
+)
+
+#define _ndarray3_assert_bounds(_n, _n_i, _n_j, _n_k) ( \
+		   _n_i >=0 && _n_i < _n->sz[0] \
+		&& _n_j >=0 && _n_j < _n->sz[1] \
+		&& _n_k >=0 && _n_k < _n->sz[2] \
+		)
+
+
+
+/** TODO document
+ *  ndarray3_set( ndarray3* n, size_t i, size_t j, size_t k, pixel_type value )
+ */
+#define _real_ndarray3_set(_n, _n_i, _n_j, _n_k, val) \
+	do { \
+		*_ndarray3_index( (_n), (_n_i), (_n_j), (_n_k) ) = (val); \
+	} while(0)
+#ifdef NDARRAY3_ASSERT_BOUNDS_ACCESS
+  #define ndarray3_set(_n, _n_i, _n_j, _n_k, val) \
+	do { \
+		if( likely(_ndarray3_assert_bounds(_n, _n_i, _n_j, _n_k)) ) { \
+			_real_ndarray3_set(_n, _n_i, _n_j, _n_k, val); \
+		} else { \
+			die("ndarray3 (%p) access [%d,%d,%d]", _n, _n_i,_n_j,_n_k); \
+		} \
+	} while(0)
+#else
+  #define ndarray3_set(_n, _n_i, _n_j, _n_k, val) \
+	_real_ndarray3_set(_n, _n_i, _n_j, _n_k, val)
+#endif /* NDARRAY3_ASSERT_BOUNDS_ACCESS */
+
+/** TODO document
+ *  ndarray3_elems( ndarray3* n )
+ *
+ *  Number of elements in `n`. This is the product of the dimensions of `n`.
+ */
+#define ndarray3_elems(_n) ( (_n)->sz[0] * (_n)->sz[1] * (_n)->sz[2] )
+
+/** TODO document
+ *  ndarray3_get( ndarray3* n, size_t i, size_t j, size_t k              )
+ */
+#define _real_ndarray3_get(_n, _n_i, _n_j, _n_k     )    ( *_ndarray3_index( (_n), (_n_i), (_n_j), (_n_k) )       )
+
+#ifdef NDARRAY3_ASSERT_BOUNDS_ACCESS
+  #define ndarray3_get(_n, _n_i, _n_j, _n_k           )    \
+        ( \
+          ( likely(_ndarray3_assert_bounds(_n, _n_i, _n_j, _n_k )) ) \
+        ? ( _real_ndarray3_get(_n, _n_i, _n_j, _n_k     ) ) \
+        : (  die("ndarray3 (%p) access [%d,%d,%d]", _n, _n_i, _n_j, _n_k ),0 ) \
+        )
+#else
+  #define ndarray3_get(_n, _n_i, _n_j, _n_k           )   \
+        ( _real_ndarray3_get(_n, _n_i, _n_j, _n_k     ) )
+#endif /* NDARRAY3_ASSERT_BOUNDS_ACCESS */
+
+
+
+/** TODO document
+ *  NDARRAY3_LOOP_OVER_START( ndarray3* n, size_t i, size_t j, size_t k ) {
+ *      / * code body * /
+ *  } NDARRAY3_LOOP_OVER_END;
+ *
+ *      NDARRAY3_LOOP_OVER_START( n, i, j, k) {
+ *          ndarray3_set(n, i, j, k, 0);
+ *      } NDARRAY3_LOOP_OVER_END;
+ */
+#define NDARRAY3_LOOP_OVER_START( _ndarray3_var, _i0, _i1, _i2 ) \
+	do { \
+	/* start of NDARRAY3_LOOP_OVER_* */ \
+		for( size_t _i0 = 0; _i0 < _ndarray3_var->sz[0]; _i0++ ) { \
+		for( size_t _i1 = 0; _i1 < _ndarray3_var->sz[1]; _i1++ ) { \
+		for( size_t _i2 = 0; _i2 < _ndarray3_var->sz[2]; _i2++ ) { \
+			/* NDARRAY3_LOOP_OVER_* body goes here */
+
+#define NDARRAY3_LOOP_OVER_END \
+			/* NDARRAY3_LOOP_OVER_* body ends here */ \
+		} \
+		} \
+		} \
+	/* end of NDARRAY3_LOOP_OVER_* */ \
+	} while(0)
+
+#endif /* NDARRAY3_GENERIC_H */

--- a/lib/ndarray/ndarray3_generic.h
+++ b/lib/ndarray/ndarray3_generic.h
@@ -2,20 +2,20 @@
 #define NDARRAY3_GENERIC_H 1
 
 /* system headers */
-#include <stdlib.h>
-#include <stdbool.h>
+#include "util/util.h"
+#include "util/likely.h"
 
 /** TODO document
     _INDEX3D( int i, int j, int k, int size_x, int size_y,  int size_z )
  */
 #define _INDEX3D(_i, _j, _k, _sz_x, _sz_y, _sz_z)   ((_k*_sz_y+_j) * _sz_x + _i)
 
-#define _ndarray3_index(_n, _n_i, _n_j, _n_k) \
+#define _ndarray3_generic_index(_n, _n_i, _n_j, _n_k) \
 ( \
 	(_n)->p + _INDEX3D( (_n_i), (_n_j), (_n_k), (_n)->sz[0], (_n)->sz[1], (_n)->sz[2] ) \
 )
 
-#define _ndarray3_assert_bounds(_n, _n_i, _n_j, _n_k) ( \
+#define _ndarray3_generic_assert_bounds(_n, _n_i, _n_j, _n_k) ( \
 		   _n_i >=0 && _n_i < _n->sz[0] \
 		&& _n_j >=0 && _n_j < _n->sz[1] \
 		&& _n_k >=0 && _n_k < _n->sz[2] \
@@ -23,25 +23,29 @@
 
 
 
+/* NOTE: Do not make NDARRAY3_ASSERT_BOUNDS_ACCESS into
+ * NDARRAY3_GENERIC_ASSERT_BOUNDS_ACCESS. This preprocessor define is set in
+ * the build.
+ */
 /** TODO document
  *  ndarray3_set( ndarray3* n, size_t i, size_t j, size_t k, pixel_type value )
  */
-#define _real_ndarray3_set(_n, _n_i, _n_j, _n_k, val) \
+#define _real_ndarray3_generic_set(_n, _n_i, _n_j, _n_k, val) \
 	do { \
-		*_ndarray3_index( (_n), (_n_i), (_n_j), (_n_k) ) = (val); \
+		*_ndarray3_generic_index( (_n), (_n_i), (_n_j), (_n_k) ) = (val); \
 	} while(0)
 #ifdef NDARRAY3_ASSERT_BOUNDS_ACCESS
-  #define ndarray3_set(_n, _n_i, _n_j, _n_k, val) \
+  #define ndarray3_generic_set(_n, _n_i, _n_j, _n_k, val) \
 	do { \
-		if( likely(_ndarray3_assert_bounds(_n, _n_i, _n_j, _n_k)) ) { \
-			_real_ndarray3_set(_n, _n_i, _n_j, _n_k, val); \
+		if( likely(_ndarray3_generic_assert_bounds(_n, _n_i, _n_j, _n_k)) ) { \
+			_real_ndarray3_generic_set(_n, _n_i, _n_j, _n_k, val); \
 		} else { \
 			die("ndarray3 (%p) access [%d,%d,%d]", _n, _n_i,_n_j,_n_k); \
 		} \
 	} while(0)
 #else
-  #define ndarray3_set(_n, _n_i, _n_j, _n_k, val) \
-	_real_ndarray3_set(_n, _n_i, _n_j, _n_k, val)
+  #define ndarray3_generic_set(_n, _n_i, _n_j, _n_k, val) \
+	_real_ndarray3_generic_set(_n, _n_i, _n_j, _n_k, val)
 #endif /* NDARRAY3_ASSERT_BOUNDS_ACCESS */
 
 /** TODO document
@@ -49,50 +53,50 @@
  *
  *  Number of elements in `n`. This is the product of the dimensions of `n`.
  */
-#define ndarray3_elems(_n) ( (_n)->sz[0] * (_n)->sz[1] * (_n)->sz[2] )
+#define ndarray3_generic_elems(_n) ( (_n)->sz[0] * (_n)->sz[1] * (_n)->sz[2] )
 
 /** TODO document
  *  ndarray3_get( ndarray3* n, size_t i, size_t j, size_t k              )
  */
-#define _real_ndarray3_get(_n, _n_i, _n_j, _n_k     )    ( *_ndarray3_index( (_n), (_n_i), (_n_j), (_n_k) )       )
+#define _real_ndarray3_generic_get(_n, _n_i, _n_j, _n_k     )    ( *_ndarray3_generic_index( (_n), (_n_i), (_n_j), (_n_k) )       )
 
 #ifdef NDARRAY3_ASSERT_BOUNDS_ACCESS
-  #define ndarray3_get(_n, _n_i, _n_j, _n_k           )    \
+  #define ndarray3_generic_get(_n, _n_i, _n_j, _n_k           )    \
         ( \
-          ( likely(_ndarray3_assert_bounds(_n, _n_i, _n_j, _n_k )) ) \
-        ? ( _real_ndarray3_get(_n, _n_i, _n_j, _n_k     ) ) \
+          ( likely(_ndarray3_generic_assert_bounds(_n, _n_i, _n_j, _n_k )) ) \
+        ? ( _real_ndarray3_generic_get(_n, _n_i, _n_j, _n_k     ) ) \
         : (  die("ndarray3 (%p) access [%d,%d,%d]", _n, _n_i, _n_j, _n_k ),0 ) \
         )
 #else
-  #define ndarray3_get(_n, _n_i, _n_j, _n_k           )   \
-        ( _real_ndarray3_get(_n, _n_i, _n_j, _n_k     ) )
+  #define ndarray3_generic_get(_n, _n_i, _n_j, _n_k           )   \
+        ( _real_ndarray3_generic_get(_n, _n_i, _n_j, _n_k     ) )
 #endif /* NDARRAY3_ASSERT_BOUNDS_ACCESS */
 
 
 
 /** TODO document
- *  NDARRAY3_LOOP_OVER_START( ndarray3* n, size_t i, size_t j, size_t k ) {
+ *  NDARRAY3_GENERIC_LOOP_OVER_START( ndarray3* n, size_t i, size_t j, size_t k ) {
  *      / * code body * /
- *  } NDARRAY3_LOOP_OVER_END;
+ *  } NDARRAY3_GENERIC_LOOP_OVER_END;
  *
- *      NDARRAY3_LOOP_OVER_START( n, i, j, k) {
- *          ndarray3_set(n, i, j, k, 0);
- *      } NDARRAY3_LOOP_OVER_END;
+ *      NDARRAY3_GENERIC_LOOP_OVER_START( n, i, j, k) {
+ *          ndarray3_generic_set(n, i, j, k, 0);
+ *      } NDARRAY3_GENERIC_LOOP_OVER_END;
  */
-#define NDARRAY3_LOOP_OVER_START( _ndarray3_var, _i0, _i1, _i2 ) \
+#define NDARRAY3_GENERIC_LOOP_OVER_START( _ndarray3_var, _i0, _i1, _i2 ) \
 	do { \
-	/* start of NDARRAY3_LOOP_OVER_* */ \
+	/* start of NDARRAY3_GENERIC_LOOP_OVER_* */ \
 		for( size_t _i0 = 0; _i0 < _ndarray3_var->sz[0]; _i0++ ) { \
 		for( size_t _i1 = 0; _i1 < _ndarray3_var->sz[1]; _i1++ ) { \
 		for( size_t _i2 = 0; _i2 < _ndarray3_var->sz[2]; _i2++ ) { \
-			/* NDARRAY3_LOOP_OVER_* body goes here */
+			/* NDARRAY3_GENERIC_LOOP_OVER_* body goes here */
 
-#define NDARRAY3_LOOP_OVER_END \
-			/* NDARRAY3_LOOP_OVER_* body ends here */ \
+#define NDARRAY3_GENERIC_LOOP_OVER_END \
+			/* NDARRAY3_GENERIC_LOOP_OVER_* body ends here */ \
 		} \
 		} \
 		} \
-	/* end of NDARRAY3_LOOP_OVER_* */ \
+	/* end of NDARRAY3_GENERIC_LOOP_OVER_* */ \
 	} while(0)
 
 #endif /* NDARRAY3_GENERIC_H */

--- a/lib/t/ndarray/ndarray3_complex.c
+++ b/lib/t/ndarray/ndarray3_complex.c
@@ -1,0 +1,24 @@
+#include <stdlib.h>
+#include <stdio.h>
+#include <tap/basic.h>
+#include <tap/float.h>
+
+#include "ndarray/ndarray3_complex.h"
+
+int main(void) {
+	plan(1);
+
+	ndarray3_complex* n = ndarray3_complex_new( 2, 2, 2 );
+
+	ndarray3_complex_set( n, 0, 0, 0, 1 + 2 * I );
+
+	complex_pixel_type z = ndarray3_complex_get(n, 0,0,0);
+
+	diag( "%f + %fi\n", creal(z), cimag(z) );
+
+	ok(z == 1 + 2 * I, "Got the expected complex value ( 1 + 2i )");
+
+	ndarray3_complex_free(n);
+
+	return EXIT_SUCCESS;
+}


### PR DESCRIPTION
This uses the C99 complex datatype and is compatible with FFTW and KissFFT.

Fixes https://github.com/CBL-ORION/orion/issues/9.
