### PR TITLE
C TAP harness build step changed

### DIFF
--- a/tool/external/c-tap-harness/build
+++ b/tool/external/c-tap-harness/build
@@ -12,7 +12,7 @@ cd c-tap-harness/c-tap-harness
 if ! which autoconf >/dev/null; then
 	sudo apt-get install autoconf
 fi
-./autogen && ./configure && make
+./bootstrap && ./configure && make
 
 # "CFLAGS+=-fsanitize=address"
 


### PR DESCRIPTION
The `autogen` script for autoconf has been renamed to `bootstrap`.
